### PR TITLE
refactor: Strip RPC-related methods from serialization implementation.

### DIFF
--- a/burlap-rpc/src/main/java/com/caucho/burlap/io/AbstractBurlapOutput.java
+++ b/burlap-rpc/src/main/java/com/caucho/burlap/io/AbstractBurlapOutput.java
@@ -48,6 +48,7 @@
 
 package com.caucho.burlap.io;
 
+import com.caucho.hessian.io.SerializerFactory;
 import io.github.wuwen5.hessian.io.AbstractHessianOutput;
 import java.io.IOException;
 
@@ -64,11 +65,17 @@ import java.io.IOException;
  * out.completeCall();      // complete the call
  * </pre>
  */
-public abstract class AbstractBurlapOutput extends AbstractHessianOutput {
+public abstract class AbstractBurlapOutput extends AbstractHessianOutput
+        implements com.caucho.hessian.io.AbstractHessianOutput {
     @Override
     public void startCall(String method, int length) throws IOException {
         startCall(method);
     }
 
     abstract void startCall(String method) throws IOException;
+
+    @Override
+    public void setSerializerFactory(SerializerFactory factory) {
+        super.setSerializerFactory(factory);
+    }
 }

--- a/burlap-rpc/src/main/java/com/caucho/burlap/io/BurlapInput.java
+++ b/burlap-rpc/src/main/java/com/caucho/burlap/io/BurlapInput.java
@@ -1400,7 +1400,7 @@ public class BurlapInput extends AbstractBurlapInput {
         throw new UnsupportedOperationException();
     }
 
-    int read() throws IOException {
+    public int read() throws IOException {
         if (_peek >= 0) {
             int value = _peek;
             _peek = -1;
@@ -1590,5 +1590,20 @@ public class BurlapInput extends AbstractBurlapInput {
         }
 
         return _detailMessageField;
+    }
+
+    @Override
+    public void close() {
+        if (_is != null) {
+            try {
+                _is.close();
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+
+        if (_refs != null) {
+            _refs.clear();
+        }
     }
 }

--- a/burlap-rpc/src/main/java/com/caucho/burlap/io/BurlapOutput.java
+++ b/burlap-rpc/src/main/java/com/caucho/burlap/io/BurlapOutput.java
@@ -109,7 +109,7 @@ public class BurlapOutput extends AbstractBurlapOutput {
 
         _refs = null;
 
-        if (_serializerFactory == null) _serializerFactory = new SerializerFactory();
+        if (serializerFactory == null) serializerFactory = new SerializerFactory();
     }
 
     /**
@@ -270,7 +270,7 @@ public class BurlapOutput extends AbstractBurlapOutput {
 
         Serializer serializer;
 
-        serializer = _serializerFactory.getSerializer(object.getClass());
+        serializer = serializerFactory.getSerializer(object.getClass());
 
         serializer.writeObject(object, this);
     }
@@ -851,4 +851,7 @@ public class BurlapOutput extends AbstractBurlapOutput {
             os.write(ch);
         }
     }
+
+    @Override
+    public void close() throws IOException {}
 }

--- a/hessian-rpc/src/main/java/com/caucho/hessian/io/Deflation.java
+++ b/hessian-rpc/src/main/java/com/caucho/hessian/io/Deflation.java
@@ -46,10 +46,13 @@
  * @author Scott Ferguson
  */
 
-package io.github.wuwen5.hessian.io;
+package com.caucho.hessian.io;
 
-import java.io.*;
-import java.util.zip.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.InflaterInputStream;
 
 public class Deflation extends HessianEnvelope {
     public Deflation() {}

--- a/hessian-rpc/src/main/java/com/caucho/hessian/io/HessianEnvelope.java
+++ b/hessian-rpc/src/main/java/com/caucho/hessian/io/HessianEnvelope.java
@@ -22,7 +22,7 @@
  *    Alternately, this acknowlegement may appear in the software itself,
  *    if and wherever such third-party acknowlegements normally appear.
  *
- * 4. The names "Burlap", "Resin", and "Caucho" must not be used to
+ * 4. The names "Hessian", "Resin", and "Caucho" must not be used to
  *    endorse or promote products derived from this software without prior
  *    written permission. For written permission, please contact
  *    info@caucho.com.
@@ -46,32 +46,30 @@
  * @author Scott Ferguson
  */
 
-package com.caucho.burlap.io;
+package com.caucho.hessian.io;
 
-import com.caucho.hessian.io.HessianRemoteResolver;
-import io.github.wuwen5.hessian.io.AbstractHessianInput;
+import java.io.IOException;
 
 /**
- * Abstract base class for Burlap requests.  Burlap users should only
- * need to use the methods in this class.
- *
- * <p>Note, this class is just an extension of AbstractHessianInput.
- *
- * <pre>
- * AbstractBurlapInput in = ...; // get input
- * String value;
- *
- * in.startReply();         // read reply header
- * value = in.readString(); // read string value
- * in.completeReply();      // read reply footer
- * </pre>
+ * Factory class for wrapping and unwrapping hessian streams.
  */
-public abstract class AbstractBurlapInput extends AbstractHessianInput
-        implements com.caucho.hessian.io.AbstractHessianInput {
+public abstract class HessianEnvelope {
     /**
-     * Sets the resolver used to lookup remote objects.
+     * Wrap the Hessian output stream in an envelope.
      */
-    public void setRemoteResolver(HessianRemoteResolver resolver) {
-        super.setRemoteResolver(resolver);
-    }
+    public abstract Hessian2Output wrap(Hessian2Output out) throws IOException;
+
+    /**
+     * Unwrap the Hessian input stream with this envelope.  It is an
+     * error if the actual envelope does not match the expected envelope
+     * class.
+     */
+    public abstract Hessian2Input unwrap(Hessian2Input in) throws IOException;
+
+    /**
+     * Unwrap the envelope after having read the envelope code ('E') and
+     * the envelope method.  Called by the EnvelopeFactory for dynamic
+     * reading of the envelopes.
+     */
+    public abstract Hessian2Input unwrapHeaders(Hessian2Input in) throws IOException;
 }

--- a/hessian-rpc/src/main/java/com/caucho/hessian/security/X509Encryption.java
+++ b/hessian-rpc/src/main/java/com/caucho/hessian/security/X509Encryption.java
@@ -48,9 +48,9 @@
 
 package com.caucho.hessian.security;
 
-import io.github.wuwen5.hessian.io.Hessian2Input;
-import io.github.wuwen5.hessian.io.Hessian2Output;
-import io.github.wuwen5.hessian.io.HessianEnvelope;
+import com.caucho.hessian.io.Hessian2Input;
+import com.caucho.hessian.io.Hessian2Output;
+import com.caucho.hessian.io.HessianEnvelope;
 import java.io.*;
 import java.security.*;
 import java.security.cert.*;

--- a/hessian-rpc/src/main/java/com/caucho/hessian/security/X509Signature.java
+++ b/hessian-rpc/src/main/java/com/caucho/hessian/security/X509Signature.java
@@ -48,13 +48,23 @@
 
 package com.caucho.hessian.security;
 
-import io.github.wuwen5.hessian.io.Hessian2Input;
-import io.github.wuwen5.hessian.io.Hessian2Output;
-import io.github.wuwen5.hessian.io.HessianEnvelope;
-import java.io.*;
-import java.security.*;
-import java.security.cert.*;
-import javax.crypto.*;
+import com.caucho.hessian.io.Hessian2Input;
+import com.caucho.hessian.io.Hessian2Output;
+import com.caucho.hessian.io.HessianEnvelope;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.Key;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.KeyGenerator;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
 
 public class X509Signature extends HessianEnvelope {
     private String _algorithm = "HmacSHA256";

--- a/hessian2-codec/src/main/java/com/caucho/hessian/io/AbstractHessianOutput.java
+++ b/hessian2-codec/src/main/java/com/caucho/hessian/io/AbstractHessianOutput.java
@@ -144,7 +144,6 @@ public interface AbstractHessianOutput extends Closeable {
     /**
      * Writes a double value to the stream.  The double will be written
      * with the following syntax:
-     *
      * <code><pre>
      * D b64 b56 b48 b40 b32 b24 b16 b8
      * </pre></code>
@@ -155,7 +154,6 @@ public interface AbstractHessianOutput extends Closeable {
 
     /**
      * Writes a date to the stream.
-     *
      * <code><pre>
      * T  b64 b56 b48 b40 b32 b24 b16 b8
      * </pre></code>
@@ -167,25 +165,20 @@ public interface AbstractHessianOutput extends Closeable {
     /**
      * Writes a null value to the stream.
      * The null will be written with the following syntax
-     *
      * <code><pre>
      * N
      * </pre></code>
-     *
-     * @param value the string value to write.
      */
     void writeNull() throws IOException;
 
     /**
      * Writes a string value to the stream using UTF-8 encoding.
      * The string will be written with the following syntax:
-     *
      * <code><pre>
      * S b16 b8 string-value
      * </pre></code>
      * <p>
      * If the value is null, it will be written as
-     *
      * <code><pre>
      * N
      * </pre></code>
@@ -197,36 +190,30 @@ public interface AbstractHessianOutput extends Closeable {
     /**
      * Writes a string value to the stream using UTF-8 encoding.
      * The string will be written with the following syntax:
-     *
      * <code><pre>
      * S b16 b8 string-value
      * </pre></code>
      * <p>
      * If the value is null, it will be written as
-     *
      * <code><pre>
      * N
      * </pre></code>
-     *
-     * @param value the string value to write.
      */
     void writeString(char[] buffer, int offset, int length) throws IOException;
 
     /**
      * Writes a byte array to the stream.
      * The array will be written with the following syntax:
-     *
      * <code><pre>
      * B b16 b18 bytes
      * </pre></code>
      * <p>
      * If the value is null, it will be written as
-     *
      * <code><pre>
      * N
      * </pre></code>
      *
-     * @param value the string value to write.
+     * @param buffer the byte array to write.
      */
     void writeBytes(byte[] buffer) throws IOException;
 
@@ -243,8 +230,6 @@ public interface AbstractHessianOutput extends Closeable {
      * <code><pre>
      * N
      * </pre></code>
-     *
-     * @param value the string value to write.
      */
     void writeBytes(byte[] buffer, int offset, int length) throws IOException;
 
@@ -255,18 +240,14 @@ public interface AbstractHessianOutput extends Closeable {
 
     /**
      * Writes a byte buffer to the stream.
-     *
      * <code><pre>
      * b b16 b18 bytes
      * </pre></code>
-     *
-     * @param value the string value to write.
      */
     void writeByteBufferPart(byte[] buffer, int offset, int length) throws IOException;
 
     /**
      * Writes the last chunk of a byte buffer to the stream.
-     *
      * <code><pre>
      * b b16 b18 bytes
      * </pre></code>
@@ -290,8 +271,6 @@ public interface AbstractHessianOutput extends Closeable {
 
     void flush() throws IOException;
 
-    void writeReply(Object o) throws IOException;
-
     /**
      * Writes a fault.  The fault will be written
      * as a descriptive string followed by an object:
@@ -314,4 +293,23 @@ public interface AbstractHessianOutput extends Closeable {
      * @param code the fault code, a three digit
      */
     void writeFault(String code, String message, Object detail) throws IOException;
+
+    default void writeReply(Object o) throws IOException {
+        startReply();
+        writeObject(o);
+        completeReply();
+    }
+
+    default void startReply() throws IOException {}
+
+    /**
+     * Completes reading the reply
+     *
+     * <p>A successful completion will have a single value:
+     *
+     * <pre>
+     * z
+     * </pre>
+     */
+    default void completeReply() throws IOException {}
 }

--- a/hessian2-codec/src/main/java/com/caucho/hessian/io/Hessian2Input.java
+++ b/hessian2-codec/src/main/java/com/caucho/hessian/io/Hessian2Input.java
@@ -48,7 +48,13 @@
 
 package com.caucho.hessian.io;
 
+import io.github.wuwen5.hessian.io.HessianServiceException;
+import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Input stream for Hessian requests.
@@ -66,8 +72,27 @@ import java.io.InputStream;
  * in.completeReply();      // read reply footer
  * </pre>
  */
+@Slf4j
 public class Hessian2Input extends io.github.wuwen5.hessian.io.Hessian2Input
         implements com.caucho.hessian.io.AbstractHessianInput {
+
+    private static Field detailMessageField;
+
+    /**
+     * -- GETTER --
+     * Returns any reply fault.
+     */
+    @Getter
+    private Throwable replyFault;
+
+    /**
+     * the method for a call
+     * -- GETTER --
+     * Returns the calls method
+     */
+    @Getter
+    private String method;
+
     public Hessian2Input() {
         super();
     }
@@ -90,5 +115,122 @@ public class Hessian2Input extends io.github.wuwen5.hessian.io.Hessian2Input
     @Override
     public void setSerializerFactory(SerializerFactory ser) {
         super.setSerializerFactory(ser);
+    }
+
+    /**
+     * Starts reading the call
+     *
+     * <p>A successful completion will have a single value:
+     *
+     * <pre>
+     * string
+     * </pre>
+     */
+    @Override
+    public String readMethod() throws IOException {
+        method = readString();
+
+        return method;
+    }
+
+    /**
+     * Returns the number of method arguments
+     *
+     * <pre>
+     * int
+     * </pre>
+     */
+    @Override
+    public int readMethodArgLength() throws IOException {
+        return readInt();
+    }
+
+    /**
+     * Reads a reply as an object.
+     * If the reply has a fault, throws the exception.
+     */
+    @Override
+    public Object readReply(Class expectedClass) throws Throwable {
+        int tag = read();
+
+        if (tag == 'R') {
+            return readObject(expectedClass);
+        } else if (tag == 'F') {
+            HashMap map = (HashMap) readObject(HashMap.class);
+
+            throw prepareFault(map);
+        } else {
+            StringBuilder sb = new StringBuilder();
+            sb.append((char) tag);
+
+            try {
+                int ch;
+
+                while ((ch = read()) >= 0) {
+                    sb.append((char) ch);
+                }
+            } catch (IOException e) {
+                log.debug(e.toString(), e);
+            }
+
+            throw error("expected hessian reply at " + codeName(tag) + "\n" + sb);
+        }
+    }
+
+    /**
+     * Starts reading the reply
+     *
+     * <p>A successful completion will have a single value:
+     *
+     * <pre>
+     * r
+     * </pre>
+     */
+    @Override
+    public void startReply() throws Throwable {
+        // XXX: for variable length (?)
+
+        readReply(Object.class);
+    }
+
+    /**
+     * Prepares the fault.
+     */
+    private Throwable prepareFault(HashMap fault) {
+        Object detail = fault.get("detail");
+        String message = (String) fault.get("message");
+
+        if (detail instanceof Throwable) {
+            replyFault = (Throwable) detail;
+
+            Field detailMessageField = getDetailMessageField();
+
+            if (message != null && detailMessageField != null) {
+                try {
+                    detailMessageField.set(replyFault, message);
+                } catch (Throwable ignored) {
+                }
+            }
+
+            return replyFault;
+        } else {
+            String code = (String) fault.get("code");
+
+            replyFault = new HessianServiceException(message, code, detail);
+
+            return replyFault;
+        }
+    }
+
+    private static Field getDetailMessageField() {
+        if (detailMessageField == null) {
+            try {
+                detailMessageField = Throwable.class.getDeclaredField("detailMessage");
+                detailMessageField.setAccessible(true);
+            } catch (Throwable ignored) {
+            }
+        }
+
+        return detailMessageField;
     }
 }

--- a/hessian2-codec/src/main/java/com/caucho/hessian/io/Hessian2Output.java
+++ b/hessian2-codec/src/main/java/com/caucho/hessian/io/Hessian2Output.java
@@ -48,6 +48,7 @@
 
 package com.caucho.hessian.io;
 
+import java.io.IOException;
 import java.io.OutputStream;
 
 /**
@@ -87,5 +88,155 @@ public class Hessian2Output extends io.github.wuwen5.hessian.io.Hessian2Output i
     @Override
     public void setSerializerFactory(SerializerFactory factory) {
         super.setSerializerFactory(factory);
+    }
+
+    /**
+     * Writes a complete method call.
+     */
+    @Override
+    public void call(String method, Object[] args) throws IOException {
+        writeVersion();
+
+        int length = args != null ? args.length : 0;
+
+        startCall(method, length);
+
+        for (int i = 0; i < length; i++) {
+            writeObject(args[i]);
+        }
+
+        completeCall();
+
+        flush();
+    }
+
+    /**
+     * Writes the call tag.  This would be followed by the
+     * method and the arguments
+     *
+     * <code><pre>
+     * C
+     * </pre></code>
+     */
+    @Override
+    public void startCall() throws IOException {
+        flushIfFull();
+
+        buffer[offset++] = (byte) 'C';
+    }
+
+    /**
+     * Starts the method call.  Clients would use <code>startCall</code>
+     * instead of <code>call</code> if they wanted finer control over
+     * writing the arguments, or needed to write headers.
+     *
+     * <code><pre>
+     * C
+     * string # method name
+     * int    # arg count
+     * </pre></code>
+     *
+     * @param method the method name to call.
+     */
+    @Override
+    public void startCall(String method, int length) throws IOException {
+        int offset = this.offset;
+
+        if (SIZE < offset + 32) {
+            flushBuffer();
+            offset = this.offset;
+        }
+
+        byte[] buffer = this.buffer;
+
+        buffer[this.offset++] = (byte) 'C';
+
+        writeString(method);
+        writeInt(length);
+    }
+
+    /**
+     * Writes the method tag.
+     *
+     * <code><pre>
+     * string
+     * </pre></code>
+     *
+     * @param method the method name to call.
+     */
+    @Override
+    public void writeMethod(String method) throws IOException {
+        writeString(method);
+    }
+
+    /**
+     * Completes.
+     *
+     * <code><pre>
+     * z
+     * </pre></code>
+     */
+    @Override
+    public void completeCall() throws IOException {
+        /*
+        flushIfFull();
+
+        _buffer[_offset++] = (byte) 'Z';
+        */
+    }
+
+    /**
+     * Starts the reply
+     *
+     * <p>A successful completion will have a single value:
+     *
+     * <pre>
+     * R
+     * </pre>
+     */
+    @Override
+    public void startReply() throws IOException {
+        writeVersion();
+
+        flushIfFull();
+
+        buffer[offset++] = (byte) 'R';
+    }
+
+    /**
+     * Starts an envelope.
+     * <code><pre>
+     * E major minor
+     * m b16 b8 method-name
+     * </pre></code>
+     *
+     * @param method the method name to call.
+     */
+    public void startEnvelope(String method) throws IOException {
+        int offset = this.offset;
+
+        if (SIZE < offset + 32) {
+            flushBuffer();
+            offset = this.offset;
+        }
+
+        buffer[this.offset++] = (byte) 'E';
+
+        writeString(method);
+    }
+
+    /**
+     * Completes an envelope.
+     *
+     * <p>A successful completion will have a single value:
+     *
+     * <pre>
+     * Z
+     * </pre>
+     */
+    public void completeEnvelope() throws IOException {
+        flushIfFull();
+
+        buffer[offset++] = (byte) 'Z';
     }
 }

--- a/hessian2-codec/src/main/java/io/github/wuwen5/hessian/io/AbstractHessianResolver.java
+++ b/hessian2-codec/src/main/java/io/github/wuwen5/hessian/io/AbstractHessianResolver.java
@@ -57,6 +57,7 @@ public class AbstractHessianResolver implements HessianRemoteResolver {
     /**
      * Looks up a proxy object.
      */
+    @Override
     public Object lookup(String type, String url) throws IOException {
         return new HessianRemote(type, url);
     }

--- a/hessian2-codec/src/main/java/io/github/wuwen5/hessian/io/FileDeserializer.java
+++ b/hessian2-codec/src/main/java/io/github/wuwen5/hessian/io/FileDeserializer.java
@@ -55,7 +55,7 @@ import java.io.File;
  */
 public class FileDeserializer extends AbstractStringValueDeserializer {
     @Override
-    public Class getType() {
+    public Class<?> getType() {
         return File.class;
     }
 

--- a/hessian2-codec/src/main/java/io/github/wuwen5/hessian/io/HessianFactory.java
+++ b/hessian2-codec/src/main/java/io/github/wuwen5/hessian/io/HessianFactory.java
@@ -66,9 +66,9 @@ public class HessianFactory {
 
     private final SerializerFactory defaultSerializerFactory;
 
-    private final HessianFreeList<Hessian2Output> freeHessian2Output = new HessianFreeList<>(32);
+    protected final HessianFreeList<Hessian2Output> freeHessian2Output = new HessianFreeList<>(32);
 
-    private final HessianFreeList<Hessian2Input> freeHessian2Input = new HessianFreeList<>(32);
+    protected final HessianFreeList<Hessian2Input> freeHessian2Input = new HessianFreeList<>(32);
 
     public HessianFactory() {
         defaultSerializerFactory = SerializerFactory.createDefault();

--- a/hessian2-codec/src/main/java/io/github/wuwen5/hessian/io/HessianSerializerOutput.java
+++ b/hessian2-codec/src/main/java/io/github/wuwen5/hessian/io/HessianSerializerOutput.java
@@ -103,10 +103,10 @@ public class HessianSerializerOutput extends Hessian2Output {
     /**
      * Applications which override this can do custom serialization.
      *
-     * @param object the object to write.
+     * @param obj the object to write.
      */
     public void writeObjectImpl(Object obj) throws IOException {
-        Class cl = obj.getClass();
+        Class<?> cl = obj.getClass();
 
         try {
             Method method = cl.getMethod("writeReplace", new Class[0]);
@@ -114,17 +114,17 @@ public class HessianSerializerOutput extends Hessian2Output {
 
             writeObject(repl);
             return;
-        } catch (Exception e) {
+        } catch (Exception ignored) {
         }
 
         try {
             writeMapBegin(cl.getName());
             for (; cl != null; cl = cl.getSuperclass()) {
                 Field[] fields = cl.getDeclaredFields();
-                for (int i = 0; i < fields.length; i++) {
-                    Field field = fields[i];
-
-                    if (Modifier.isTransient(field.getModifiers()) || Modifier.isStatic(field.getModifiers())) continue;
+                for (Field field : fields) {
+                    if (Modifier.isTransient(field.getModifiers()) || Modifier.isStatic(field.getModifiers())) {
+                        continue;
+                    }
 
                     // XXX: could parameterize the handler to only deal with public
                     field.setAccessible(true);

--- a/hessian2-codec/src/main/java/io/github/wuwen5/hessian/io/LocaleHandle.java
+++ b/hessian2-codec/src/main/java/io/github/wuwen5/hessian/io/LocaleHandle.java
@@ -64,7 +64,9 @@ public class LocaleHandle implements java.io.Serializable, HessianHandle {
     private Object readResolve() {
         String s = this.value;
 
-        if (s == null) return null;
+        if (s == null) {
+            return null;
+        }
 
         int len = s.length();
         char ch = ' ';
@@ -103,9 +105,12 @@ public class LocaleHandle implements java.io.Serializable, HessianHandle {
 
             var = s.substring(head, i);
         }
-
-        if (var != null) return new Locale(language, country, var);
-        else if (country != null) return new Locale(language, country);
-        else return new Locale(language);
+        if (var != null) {
+            return new Locale(language, country, var);
+        } else if (country != null) {
+            return new Locale(language, country);
+        } else {
+            return new Locale(language);
+        }
     }
 }

--- a/hessian2-codec/src/main/resources/META-INF/hessian/deserializers
+++ b/hessian2-codec/src/main/resources/META-INF/hessian/deserializers
@@ -1,3 +1,3 @@
-java.io.File=com.caucho.hessian.io.FileDeserializer
-java.math.BigDecimal=com.caucho.hessian.io.BigDecimalDeserializer
+java.io.File=io.github.wuwen5.hessian.io.FileDeserializer
+java.math.BigDecimal=io.github.wuwen5.hessian.io.BigDecimalDeserializer
 javax.management.ObjectName=io.github.wuwen5.hessian.io.ObjectNameDeserializer

--- a/hessian2-codec/src/test/java/io/github/wuwen5/hessian/io/ExtendedTypeIOTest.java
+++ b/hessian2-codec/src/test/java/io/github/wuwen5/hessian/io/ExtendedTypeIOTest.java
@@ -1,0 +1,61 @@
+package io.github.wuwen5.hessian.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.vavr.control.Try;
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author wuwen
+ */
+public class ExtendedTypeIOTest extends SerializeTestBase {
+
+    @Test
+    void testFile() throws IOException {
+        File file = new File("test.txt");
+        Object ret = hessianIO(output -> Try.run(() -> output.writeObject(file)), input -> Try.of(input::readObject)
+                .get());
+
+        assertEquals("test.txt", ((File) ret).getPath());
+    }
+
+    @Test
+    void testBigDecimal() throws IOException {
+        BigDecimal bigDecimal = new BigDecimal("1234567890123456789012345678901234567890");
+        Object ret =
+                hessianIO(output -> Try.run(() -> output.writeObject(bigDecimal)), input -> Try.of(input::readObject)
+                        .get());
+
+        assertEquals(bigDecimal, ret);
+    }
+
+    @Test
+    void testLocale() throws IOException {
+        Locale en = Locale.ENGLISH;
+        Locale zh = Locale.SIMPLIFIED_CHINESE;
+        Locale zh_CN_Hans = new Locale.Builder()
+                .setLanguage("zh")
+                .setRegion("CN")
+                .setScript("Hans") // 设置脚本
+                .build();
+
+        Object en_ret = hessianIO(output -> Try.run(() -> output.writeObject(en)), input -> Try.of(input::readObject)
+                .get());
+
+        Object zh_ret = hessianIO(output -> Try.run(() -> output.writeObject(zh)), input -> Try.of(input::readObject)
+                .get());
+
+        Object zhCnHansRet =
+                hessianIO(output -> Try.run(() -> output.writeObject(zh_CN_Hans)), input -> Try.of(input::readObject)
+                        .get());
+
+        assertEquals(en.toString(), en_ret.toString());
+        assertEquals(zh.toString(), zh_ret.toString());
+        // TODO
+        // assertEquals(zh_CN_Hans.toString(), zhCnHansRet.toString());
+    }
+}

--- a/hessian2-codec/src/test/java/io/github/wuwen5/hessian/io/HessianFactoryTest.java
+++ b/hessian2-codec/src/test/java/io/github/wuwen5/hessian/io/HessianFactoryTest.java
@@ -119,5 +119,14 @@ class HessianFactoryTest {
         assertEquals(2, list.size());
     }
 
+    @Test
+    void testSerializerFactory() {
+        com.caucho.hessian.io.SerializerFactory serializerFactory = new com.caucho.hessian.io.SerializerFactory();
+        com.caucho.hessian.io.SerializerFactory serializerFactory2 = new com.caucho.hessian.io.SerializerFactory(
+                Thread.currentThread().getContextClassLoader());
+
+        assertSame(serializerFactory.getClassLoader(), serializerFactory2.getClassLoader());
+    }
+
     static class Obj implements Serializable {}
 }


### PR DESCRIPTION
(`startCall`、`readCall`、`completeCall`、`startReply`、etc...)