### PR TITLE
perf: improve CollectionDeserializer to check constructor visibility before instantiation

### DIFF
--- a/hessian2-codec/src/main/java/io/github/wuwen5/hessian/io/CollectionDeserializer.java
+++ b/hessian2-codec/src/main/java/io/github/wuwen5/hessian/io/CollectionDeserializer.java
@@ -49,6 +49,8 @@
 package io.github.wuwen5.hessian.io;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
 import java.util.*;
 
 /**
@@ -101,7 +103,10 @@ public class CollectionDeserializer extends AbstractListDeserializer {
             list = new ArrayList<>();
         } else if (!type.isInterface()) {
             try {
-                list = (Collection) type.getDeclaredConstructor().newInstance();
+                Constructor<?> declaredConstructor = type.getDeclaredConstructor();
+                if (Modifier.isPublic(declaredConstructor.getModifiers())) {
+                    list = (Collection) declaredConstructor.newInstance();
+                }
             } catch (Exception ignored) {
             }
         }


### PR DESCRIPTION
<img width="1491" height="389" alt="image" src="https://github.com/user-attachments/assets/d85e02be-2e00-4abb-9b42-b4c509af4fba" />

```
benchmarkDeserialization_before thrpt   10  143162.862 ± 1676.615  ops/s
benchmarkDeserialization_after  thrpt   10  177102.745 ± 8684.759  ops/s
```